### PR TITLE
Use HTTP instead of HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ Sure, check `whatthecommit -h` for usage and options.
 #### Do I need this? / Alternatives
 
 No, [whatthecommit.com][wtc] provides since some time a
-plain text interface at https://whatthecommit.com/index.txt - so a good
+plain text interface at http://whatthecommit.com/index.txt - so a good
 alternative would be to create something like:
 
 ```bash
 # .bashrc / .zshrc or whatever
 function whatthecommit() {
-  curl --silent --fail https://whatthecommit.com/index.txt
+  curl --silent --fail http://whatthecommit.com/index.txt
 }
 ```
 
@@ -47,9 +47,9 @@ function whatthecommit() {
 
 ```bash
 # From https://github.com/ngerakines/commitment/issues/69#issuecomment-91053061
-git config --global alias.yolo '!git add -A && git commit -m "$(curl --silent --fail https://whatthecommit.com/index.txt)"'
+git config --global alias.yolo '!git add -A && git commit -m "$(curl --silent --fail http://whatthecommit.com/index.txt)"'
 ```
 
 Thanks to [m13253](https://github.com/m13253) for the index.txt trick.
 
-[wtc]: https://whatthecommit.com/
+[wtc]: http://whatthecommit.com/

--- a/whatthecommit
+++ b/whatthecommit
@@ -5,7 +5,7 @@ require 'open-uri'
 
 class WhatTheCommit
   VERSION = "1.1.0"
-  URL = "https://whatthecommit.com/index.txt"
+  URL = "http://whatthecommit.com/index.txt"
 
   attr_reader :disclaimer, :iterations
 


### PR DESCRIPTION
## Problem

whatthecommit.com does not support https (anymore?). All links of the form https://whatthecommit.com return `ERR_SSL_UNRECOGNIZED_NAME_ALERT`, aka just do not work.

## Solution

```bash
sed -i 's|https://whatthecommit|http://whatthecommit|g' *
```

## Alternative
Hope whatthecommit supports https. But for a "tool" like this this seems to be not a real priority. I guess, this "fix" makes #5 even more relevant if valid. However, since executing random code from the internet is insecure in the first place I think it's not really making it more dangerous than it already is. ¯\\\_(ツ)\_/¯